### PR TITLE
Update entrypoint.sh

### DIFF
--- a/haproxy-confd/entrypoint.sh
+++ b/haproxy-confd/entrypoint.sh
@@ -24,7 +24,7 @@ until confd -onetime -node "$ETCD_NODE"; do
   if [ "$n" -eq "4" ];  then config_fail; fi
   echo "[haproxy-confd] waiting for confd to refresh haproxy.cfg"
   n=$((n+1))
-  sleep n
+  sleep $n
 done
 
 echo "[haproxy-confd] Initial HAProxy config created. Starting confd"


### PR DESCRIPTION
Fixes

``` bash
sleep: invalid time interval `n'
Try `sleep --help' for more information.
```
