### PR TITLE
Change and expose haproxy stats port

### DIFF
--- a/haproxy-confd/Dockerfile
+++ b/haproxy-confd/Dockerfile
@@ -27,3 +27,4 @@ ADD confd /etc/confd
 	
 # Expose ports.
 EXPOSE 8080
+EXPOSE 8090

--- a/haproxy-confd/confd/templates/haproxy.tmpl
+++ b/haproxy-confd/confd/templates/haproxy.tmpl
@@ -69,7 +69,7 @@ listen {{$name}}
 
 listen MyStats
     mode http
-    bind 0.0.0.0:1000
+    bind 0.0.0.0:8090
     stats enable
     stats uri /
     stats refresh 5s


### PR DESCRIPTION
Running haproxy stats on port 1000 requires the container to run as privileged. Plus the port was not exposed - so it could not be published form the docker host. I've changed the port to 8090 and exposed it as well in the Dockerfile.
