### PR TITLE
Allow extra options via DUPLICITY_OPTIONS

### DIFF
--- a/backup-volume-container/run.sh
+++ b/backup-volume-container/run.sh
@@ -24,15 +24,12 @@ echo "Updating time data to prevent problems with S3 time mismatch"
 
 inotifywait_events="modify,attrib,move,create,delete"
 
-
-ntpdate pool.ntp.org
-
 cd /var/backup
 
 # start by restoring the last backup:
 # This could fail if there's nothing to restore.
 
-duplicity --no-encryption $1 .
+duplicity $DUPLICITY_OPTIONS --no-encryption $1 .
 
 # Now, start waiting for file system events on this path.
 # After an event, wait for a quiet period of N seconds before doing a backup
@@ -44,8 +41,8 @@ while inotifywait -r -e $inotifywait_events . ; do
   done
   
   echo "starting backup"
-  duplicity --no-encryption --allow-source-mismatch --full-if-older-than 7D . $1
+  duplicity $DUPLICITY_OPTIONS --no-encryption --allow-source-mismatch --full-if-older-than 7D . $1
   echo "starting cleanup"
-  duplicity remove-all-but-n-full 3 --force --no-encryption --allow-source-mismatch $1  
-  duplicity cleanup --force --no-encryption $1
+  duplicity remove-all-but-n-full 3 $DUPLICITY_OPTIONS --force --no-encryption --allow-source-mismatch $1  
+  duplicity cleanup $DUPLICITY_OPTIONS --force --no-encryption $1
 done


### PR DESCRIPTION
EU region S3 instances needs to use --s3-european-buckets and --s3-use-new-style duplicity options. Also date update causes errors when not in priviledged mode.
