### PR TITLE
Added exclude to inotifywait

### DIFF
--- a/backup-volume-container/Dockerfile
+++ b/backup-volume-container/Dockerfile
@@ -3,6 +3,7 @@ MAINTAINER yaronr
 
 ENV AWS_ACCESS_KEY_ID foobar_aws_key_id
 ENV AWS_SECRET_ACCESS_KEY foobar_aws_access_key
+ENV INOTIFYWAIT_EXCLUDE 'matchnothing^'
 
 RUN (echo "deb http://http.debian.net/debian/ wheezy main contrib non-free" > /etc/apt/sources.list && echo "deb http://http.debian.net/debian/ wheezy-updates main contrib non-free" >> /etc/apt/sources.list && echo "deb http://security.debian.org/ wheezy/updates main contrib non-free" >> /etc/apt/sources.list) && \
 	echo "force-unsafe-io" > /etc/dpkg/dpkg.cfg.d/02apt-speedup

--- a/backup-volume-container/run.sh
+++ b/backup-volume-container/run.sh
@@ -34,9 +34,9 @@ duplicity $DUPLICITY_OPTIONS --no-encryption $1 .
 # Now, start waiting for file system events on this path.
 # After an event, wait for a quiet period of N seconds before doing a backup
 
-while inotifywait -r -e $inotifywait_events . ; do
+while inotifywait -r -e $inotifywait_events --exclude $INOTIFYWAIT_EXCLUDE . ; do
   echo "Change detected."
-  while inotifywait -r -t $2 -e $inotifywait_events . ; do
+  while inotifywait -r -t $2 -e $inotifywait_events --exclude $INOTIFYWAIT_EXCLUDE . ; do
   	echo "waiting for quiet period.."
   done
   


### PR DESCRIPTION
Hello. I really like your image. We try to use it in our stack, but one thing popup - as we try to backup our couchbase data directory, really many backups was created because couchbase has some kind of cron, which generates stats. 

To be able to use it without have backup every minute, we need to exclude some regexp from inotifywait.

We will use regexp like this: "couchbase/._stats._" to exclude all couchbase stats from triggering backup.

O course, we can create our own immage with this modification, but I think it can be useful for someone else and your image is really great, I created this PR. 

If you have some other approach to docker environmnet variables or something else, just let me know, I will rework it :-).

P.S.: the default regext `matchnothing^` really matches nothing as the string can't have "matchnothing" before it event starts :-). I just mention it, because `^` sign is really easy overlooked.
